### PR TITLE
Quaternion::fromBetweenVectors: pass u and v as const references

### DIFF
--- a/flix/quaternion.h
+++ b/flix/quaternion.h
@@ -221,9 +221,9 @@ public:
 
 	size_t printTo(Print& p) const {
 		size_t r = 0;
-		r += p.print(w, 15) + p.print(' ');
-		r += p.print(x, 15) + p.print(' ');
-		r += p.print(y, 15) + p.print(' ');
+		r += p.print(w, 15) + p.print(" ");
+		r += p.print(x, 15) + p.print(" ");
+		r += p.print(y, 15) + p.print(" ");
 		r += p.print(z, 15);
 		return r;
 	}


### PR DESCRIPTION
Previously vectors `u` and `v` were passed by value; they are now passed as const references, matching the rest of the `Quaternion` methods. This makes the interface consistent.