### PR TITLE
Add log dir creation before log writing

### DIFF
--- a/tools/log.py
+++ b/tools/log.py
@@ -43,6 +43,7 @@ records = [record for record in records if record[0] != 0]
 
 print(f'Received records: {len(records)}')
 
+os.makedirs(f'{DIR}/log', exist_ok=True)
 log = open(f'{DIR}/log/{datetime.datetime.now().isoformat()}.csv', 'wb')
 log.write(header.encode() + b'\n')
 for record in records:


### PR DESCRIPTION
tools/log directory doesn't exist in repo by default, so error occurs after first `make log` command:
```bash
$ make log
tools/log.py
flix: Connection is established
Downloading log...
Received header:
- t
- rates.x
- rates.y
- rates.z
- ratesTarget.x
- ratesTarget.y
- ratesTarget.z
- attitude.x
- attitude.y
- attitude.z
- attitudeTarget.x
- attitudeTarget.y
- attitudeTarget.z
- thrustTarget
Received records: 175
Traceback (most recent call last):
  File "/home/goldarte/side-projects/flix/tools/log.py", line 46, in <module>
    log = open(f'{DIR}/log/{datetime.datetime.now().isoformat()}.csv', 'wb')
FileNotFoundError: [Errno 2] No such file or directory: '/home/goldarte/side-projects/flix/tools/log/2026-01-22T10:32:47.263458.csv'
make: *** [Makefile:35: log] Error 1
```